### PR TITLE
Changed some data types from TINYINT to SMALLINT

### DIFF
--- a/Utils/Database/README.md
+++ b/Utils/Database/README.md
@@ -38,9 +38,9 @@
 | Attribute | Type | Description |
 | --------- | ---- | ----------- |
 | appointment_id | Integer not null | The appointment's ID|
-| weight | TINYINT | Patient's weight in pounds during specific visit |
-| height | TINYINT | Patient's height in inches during specific visit |
-| blood_pressure | TINYINT | Patient's blood pressure during specific visit |
+| weight | SMALLINT | Patient's weight in pounds during specific visit |
+| height | SMALLINT | Patient's height in inches during specific visit |
+| blood_pressure | SMALLINT | Patient's blood pressure during specific visit |
 | reason | Varchar(50) | Reason patient came to the hospital |
 | treatment_content | Varchar(50) | Details of treatment provided during specific visit |
 | prescription | Varchar(50) | Medication (if any) prescribed to patient |
@@ -54,7 +54,7 @@
 | Attribute | Type | Description |
 | --------- | ---- | ----------- |
 | id | AUTOINCREMENT Integer not null | Unique report ID |
-| type | TinyInt not null | Boolean: 1 for Daily, 2 otherwise |
+| type | TINYINT not null | Boolean: 1 for Daily, 2 otherwise |
 | doctor_name | Varchar(30) not null | Doctor's name |
 | patient_count | Integer not null | Number of patients treated by doctor |
 | total_income | Decimal(10,2) not null | Total revenue by doctor |

--- a/Utils/initdb.py
+++ b/Utils/initdb.py
@@ -53,9 +53,9 @@ TABLES['Payment'] = (
 TABLES['Reports'] = (
     "CREATE TABLE IF NOT EXISTS `Reports` ("
     "   `id` INT NOT NULL AUTO_INCREMENT,"
-    "   `type` TINYINT NOT NULL,"
+    "   `type` SMALLINT NOT NULL,"
     "   `doctor_name` VARCHAR(30) NOT NULL,"
-    "   `patient_count` TINYINT NOT NULL,"
+    "   `patient_count` SMALLINT NOT NULL,"
     "   `total_income` DECIMAL(10,2) NOT NULL,"
     "   PRIMARY KEY (`id`)"
     ") ENGINE=InnoDB")
@@ -63,9 +63,9 @@ TABLES['Reports'] = (
 TABLES['PatientRecords'] = (
     "CREATE TABLE IF NOT EXISTS `PatientRecords` ("
     "   `appointment_id` INT NOT NULL,"
-    "   `weight` TINYINT,"
-    "   `height` TINYINT,"
-    "   `blood_pressure` TINYINT,"
+    "   `weight` SMALLINT,"
+    "   `height` SMALLINT,"
+    "   `blood_pressure` SMALLINT,"
     "   `reason` Varchar(50),"
     "   `treatment_content` VARCHAR(50),"
     "   `prescription` VARCHAR(50),"


### PR DESCRIPTION
Tinyint was causing a bug in **PatientRecord** weight and height fields, because MySQL max num for TINYINT is 128. Changed to SMALLINT where applicable.