### PR TITLE
Mysql cnx adjustment

### DIFF
--- a/Utils/initdb.py
+++ b/Utils/initdb.py
@@ -119,7 +119,7 @@ TRIGGERS['daily_reports'] = ("CREATE EVENT daily_report ON SCHEDULE "
                              )
 TRIGGERS['monthly_reports'] = ("CREATE EVENT monthly_report ON SCHEDULE "
                                "EVERY 1 MONTH "
-                               "STARTS '2015-05-01 00:00:00' "
+                               "STARTS CONCAT(YEAR(CURDATE()),'-',MONTH(CURDATE()) + 1, '-01 00:00:00') "
                                "ON COMPLETION PRESERVE ENABLE "
                                "DO "
                                "INSERT INTO reports (type, doctor_name, "

--- a/src/appointments/db.js
+++ b/src/appointments/db.js
@@ -1,4 +1,5 @@
-const connection = require('../db-connection.js'); // Get connection to MySQL
+const db = require('../db-connection.js'); // Get connection to MySQL
+const connection = db.connection;
 
 /**
 * createApp: create an appointment
@@ -6,11 +7,10 @@ const connection = require('../db-connection.js'); // Get connection to MySQL
 **/
 const createApp = (params, callback) => {
   // Insert appointments
-  let query = connection.query("INSERT INTO appointments SET ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("INSERT INTO appointments SET ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -19,11 +19,10 @@ const createApp = (params, callback) => {
 **/
 const modifyApp = (params, callback) => {
   // Modify appointments
-  let query = connection.query("UPDATE appointments SET ? WHERE ?",
-                                 params, (err, response, fields) => {
-                                    callback(err, response, fields);
-                                 });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("UPDATE appointments SET ? WHERE ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -33,11 +32,10 @@ const modifyApp = (params, callback) => {
 **/
 const deleteApp = (params, callback) => {
   // Delete appointments
-  let query = connection.query("DELETE FROM appointments WHERE ?;" ,
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("DELETE FROM appointments WHERE ?;" ,
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -46,12 +44,11 @@ const deleteApp = (params, callback) => {
 **/
 const getUncompApps = (params, callback) => {
   // Get all incomplete appointments for month in params
-  let query = connection.query("SELECT * FROM appointments WHERE " +
-                                " MONTH(date_time) = ? AND ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM appointments WHERE " +
+                " MONTH(date_time) = ? AND ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -59,11 +56,10 @@ const getUncompApps = (params, callback) => {
 * arg params: a JSONArray with [{patient_id}]
 **/
 const getAppsByPatient = (params, callback) => {
-  let query = connection.query("SELECT * FROM appointments WHERE ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM appointments WHERE ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -72,12 +68,11 @@ const getAppsByPatient = (params, callback) => {
 * arg params: a JSONArray with [month, {patient_id}, {completed}]
 **/
 const getUncompAppsByPatient = (params, callback) => {
-  let query = connection.query("SELECT * FROM appointments WHERE " +
-                                " MONTH(date_time) = ? AND ? AND ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM appointments WHERE " +
+                " MONTH(date_time) = ? AND ? AND ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -86,12 +81,11 @@ const getUncompAppsByPatient = (params, callback) => {
 * arg params: a JSONArray with [month, {employee_id}, {completed}]
 **/
 const getUncompAppsByDoctor = (params, callback) => {
-  let query = connection.query("SELECT * FROM appointments WHERE " +
-                                " MONTH(date_time) = ? AND ? AND ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM appointments WHERE " +
+                " MONTH(date_time) = ? AND ? AND ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 // Export all functions so that manager.js can find/use them in functions.

--- a/src/db-connection.js
+++ b/src/db-connection.js
@@ -1,13 +1,28 @@
 const mysql = require('mysql');
 
-// Establish connection
-const connection = mysql.createConnection({
-    host      :'localhost',
-    user      :'root',
-    password  :'password',
-    database  :'healthcaredb',
-    multipleStatements : true
+const dbConfig = {
+  host      :'localhost',
+  user      :'root',
+  password  :'password',
+  database  :'healthcaredb',
+  multipleStatements : true,
+  connectionLimit : 10
+};
+
+const pool = mysql.createPool(dbConfig);
+
+// Function to handle any and all database queries
+const executeSQL = (sql, params, callback) => {
+  pool.getConnection((err, cnx) => {
+    if(err) {
+      console.log(err);
+    } else {
+      let query = cnx.query(sql, params, callback);
+      cnx.release();
+      console.log('Ran query: ', query.sql);
+    }
   });
+}
 
 // Export connection
-module.exports = connection;
+module.exports = {executeSQL};

--- a/src/db-connection.js
+++ b/src/db-connection.js
@@ -9,9 +9,15 @@ const dbConfig = {
   connectionLimit : 10
 };
 
-const pool = mysql.createPool(dbConfig);
+const pool = mysql.createPool(dbConfig); // create a pool of 10 connections
 
-// Function to handle any and all database queries
+/**
+* executeSQL: execute sql against the databse in dbConfig
+* get a connection from the connection pool
+* execute the statement in the variable sql and send the
+* response back to the calling function through callback
+* release the connection back to the pool
+**/
 const executeSQL = (sql, params, callback) => {
   pool.getConnection((err, cnx) => {
     if(err) {

--- a/src/employees/db.js
+++ b/src/employees/db.js
@@ -1,4 +1,5 @@
-const connection = require('../db-connection.js'); // Get connection to MySQL
+const db = require('../db-connection.js'); // Get connection to MySQL
+const connection = db.connection;
 
 /**
 * getAllDoctors: get a list of all doctors
@@ -6,11 +7,10 @@ const connection = require('../db-connection.js'); // Get connection to MySQL
 **/
 const getAllDoctors = (params, callback) => {
   // Gets a list of all doctors
-  let query = connection.query("SELECT * FROM employees WHERE ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM employees WHERE ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 module.exports = {getAllDoctors};

--- a/src/patient_records/db.js
+++ b/src/patient_records/db.js
@@ -1,4 +1,5 @@
-const connection = require('../db-connection.js'); // Get connection to MySQL
+const db = require('../db-connection.js'); // Get connection to MySQL
+const connection = db.connection;
 
 
 /**
@@ -7,11 +8,10 @@ const connection = require('../db-connection.js'); // Get connection to MySQL
 **/
 const modifyRecord = (params, callback) => {
   // Modify patient record
-  let query = connection.query("UPDATE patientrecords SET ? WHERE ?",
-                                 params, (err, response, fields) => {
-                                    callback(err, response, fields);
-                                 });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("UPDATE patientrecords SET ? WHERE ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -20,11 +20,10 @@ const modifyRecord = (params, callback) => {
 **/
 const getRecordById = (params, callback) => {
   // get record by id
-  let query = connection.query("SELECT * FROM patientrecords WHERE ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response[0], fields);
-                                });
-  console.log('Ran query: ' + query.sql);
+  db.executeSQL("SELECT * FROM patientrecords WHERE ?",
+                params, (err, response, fields) => {
+                        callback(err, response[0], fields);
+                });
 }
 
 module.exports = {modifyRecord, getRecordById};

--- a/src/patients/db.js
+++ b/src/patients/db.js
@@ -1,4 +1,4 @@
-const connection = require('../db-connection.js'); // Get connection to MySQL
+const db = require('../db-connection.js'); // Get connection to MySQL
 
 /**
 * createPatient: create a patient
@@ -6,11 +6,10 @@ const connection = require('../db-connection.js'); // Get connection to MySQL
 **/
 const createPatient = (params, callback) => {
   // Create a patient
-  let query = connection.query("INSERT INTO patients SET ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("INSERT INTO patients SET ?",
+                params, (err, response, fields) => {
+                        callback(err, response, fields);
+                });
 }
 
 /**
@@ -18,11 +17,10 @@ const createPatient = (params, callback) => {
 *
 **/
 const getAllPatients = (callback) => {
-  let query = connection.query("SELECT * FROM patients",
-                                (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM patients",
+                (err, response, fields) => {
+                      callback(err, response, fields);
+                });
 }
 
 /**
@@ -30,11 +28,10 @@ const getAllPatients = (callback) => {
 * arg params: a JSONArray with [{id}]
 **/
 const getPatientById = (params, callback) => {
-  let query = connection.query("SELECT * FROM patients WHERE ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response[0], fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM patients WHERE ?",
+                params, (err, response, fields) => {
+                        callback(err, response[0], fields);
+                });
 }
 
 // Export all functions so that manager.js can find/use them in functions.

--- a/src/payments/db.js
+++ b/src/payments/db.js
@@ -1,15 +1,14 @@
-const connection = require('../db-connection.js'); // Get connection to MySQL
+const db = require('../db-connection.js'); // Get connection to MySQL
 
 /**
 * getPaymentById: get invoice payment information by id
 * arg params: a JSONObject with {id}
 **/
 const getPaymentById = (params, callback) => {
-  let query = connection.query("SELECT * FROM payments WHERE ? AND ?;",
-                                params, (err, response, fields) => {
-                                  callback(err, response[0], fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM payments WHERE ? AND ?;",
+                params, (err, response, fields) => {
+                        callback(err, response[0], fields);
+                });
 }
 
 /**
@@ -17,11 +16,10 @@ const getPaymentById = (params, callback) => {
 * arg params: a JSONArray with [{appointment_id}, {type}]
 **/
 const getCopayByApp = (params, callback) => {
-  let query = connection.query("SELECT * FROM payments WHERE ? and ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response[0], fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM payments WHERE ? and ?",
+                params, (err, response, fields) => {
+                        callback(err, response[0], fields);
+                });
 }
 
 /**
@@ -31,12 +29,11 @@ const getCopayByApp = (params, callback) => {
 **/
 const modifyCopay = (params, callback) => {
   // Modify payment
-  let query = connection.query("UPDATE payments SET ? WHERE ? AND ?;" +
-                               "SELECT * FROM payments WHERE ? AND ?;",
-                                 params, (err,response,fields) => {
-                                   callback(err, response[1], fields);
-                                 });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("UPDATE payments SET ? WHERE ? AND ?;" +
+                "SELECT * FROM payments WHERE ? AND ?;",
+                params, (err,response,fields) => {
+                        callback(err, response[1], fields);
+                });
 }
 
 /**
@@ -46,12 +43,11 @@ const modifyCopay = (params, callback) => {
 **/
 const modifyInvoice = (params, callback) => {
   // Modify payment
-  let query = connection.query("UPDATE payments SET ? WHERE ? AND ?;" +
-                               "SELECT * FROM payments WHERE ? AND ?;",
-                                 params, (err,response,fields) => {
-                                   callback(err, response[1], fields);
-                                 });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("UPDATE payments SET ? WHERE ? AND ?;" +
+                "SELECT * FROM payments WHERE ? AND ?;",
+                params, (err,response,fields) => {
+                         callback(err, response[1], fields);
+                });
 }
 
 // Export all functions so that router.js can find/use them in endpoints.

--- a/src/reports/db.js
+++ b/src/reports/db.js
@@ -5,13 +5,10 @@ const db = require('../db-connection.js'); // Get connection to MySQL
 * arg params: a JSONObject with {type}
 **/
 const getAllDailyReports = (params, callback) => {
-  // let query = connection.query("SELECT * FROM reports WHERE ?",
-  //                               params, (err, response, fields) => {
-  //                                 callback(err, response, fields);
-  //                               });
-  // console.log('Ran query: ' + query.sql); // Log executed sql
-  let sql = "SELECT * FROM reports WHERE ?";
-  db.executeSQL(sql, params, callback);
+  db.executeSQL("SELECT * FROM reports WHERE ?",
+                                params, (err, response, fields) => {
+                                  callback(err, response, fields);
+                                });
 }
 
 /**
@@ -19,13 +16,10 @@ const getAllDailyReports = (params, callback) => {
 * arg params: a JSONObject with {type}
 **/
 const getAllMonthlyReports = (params, callback) => {
-  let query = connection.query("SELECT * FROM reports WHERE ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  db.executeSQL("SELECT * FROM reports WHERE ?",
+                params, (err, response, fields) => {
+                  callback(err, response, fields);
+                });
 }
-
-
 
 module.exports = {getAllDailyReports, getAllMonthlyReports};

--- a/src/reports/db.js
+++ b/src/reports/db.js
@@ -1,16 +1,17 @@
-const connection = require('../db-connection.js'); // Get connection to MySQL
-
+const db = require('../db-connection.js'); // Get connection to MySQL
 
 /**
 * getAllDailyReports: get all daily reports
 * arg params: a JSONObject with {type}
 **/
 const getAllDailyReports = (params, callback) => {
-  let query = connection.query("SELECT * FROM reports WHERE ?",
-                                params, (err, response, fields) => {
-                                  callback(err, response, fields);
-                                });
-  console.log('Ran query: ' + query.sql); // Log executed sql
+  // let query = connection.query("SELECT * FROM reports WHERE ?",
+  //                               params, (err, response, fields) => {
+  //                                 callback(err, response, fields);
+  //                               });
+  // console.log('Ran query: ' + query.sql); // Log executed sql
+  let sql = "SELECT * FROM reports WHERE ?";
+  db.executeSQL(sql, params, callback);
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const db = require('./db-connection.js');
 
 const appointments = require('./appointments/router');
 const patients = require('./patients/router');


### PR DESCRIPTION
Updated `db-connection.js` and every `src/xxx/db.js` file to use and release connections to the MySQL server from a pool of 10 connections. 

This should solve the bug of losing connections to the MySQL server after timeout. 

Notice each function in `src/xxx/db.js` now uses `db.exececuteSQL()` to execute any sql statements. 

From the mysql docs:

> The pool will create a new connection the next time one is needed.
> Connections are lazily created by the pool. If you configure the pool to allow up to 100 connections, but > only ever use 5 simultaneously, only 5 connections will be made. Connections are also cycled round-robin > style, with connections being taken from the top of the pool and returning to the bottom.
> When a previous connection is retrieved from the pool, a ping packet is sent to the server to check if the connection is still good.